### PR TITLE
Nginx setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,7 @@ project/plugins/project/
 # Scala-IDE specific
 .scala_dependencies
 .worksheet
+
+# local certificates
+*.crt
+*.key

--- a/README.md
+++ b/README.md
@@ -23,11 +23,13 @@ aws --profile identity s3 cp s3://identity-local-ssl/idadmin-thegulocal-com-exp2
 aws --profile identity s3 cp s3://identity-local-ssl/idadmin-thegulocal-com-exp2018-09-16.key . 1>/dev/null
 ```
 
-* Find the configuration folder of nginx on your machine:
+* Find the configuration folder of nginx by running:
 
 ```bash
 nginxHome=`nginx -V 2>&1 | grep "configure arguments:" | sed 's/[^*]*conf-path=\([^ ]*\)\/nginx\.conf.*/\1/g'`
 ```
+
+`echo $nginxHome` should display the name of the folder.
 
 * Create symbolic links for the certificates and identity-admin configuration file for nginx (note: this might require `sudo`)
 

--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ Ensure you have the correct [identity-admin hosts](https://github.com/guardian/i
 
 We have valid SSL certificates for thegulocal.com and the subdomains we use for local development.
 
-The certificates for the local subdomain idadmin.thegulocal.com are stored in the AWS S3 Identity bucket and are set up as part of the identity-admin.conf for nginx.
+The certificates for the local subdomain `idadmin.thegulocal.com` are stored in the AWS S3 Identity bucket and are set up as part of the `identity-admin.conf` for nginx.
 
 Follow these installation steps to correctly setup nginx and valid SSL certificates locally:
 
-* Make sure you are in the base identity-admin directory
+* Make sure you are in the base `identity-admin` directory
 
 * Make sure you have access to the S3 bucket identity-local-ssl and download them using the [AWS CLI utility](https://aws.amazon.com/cli/) (the following command will download them in your current directory using your Identity profile on AWS):
 
@@ -46,7 +46,7 @@ sudo nginx
 
 * Optional - verify that your configuration is set up as expected
 
-`ls -la $nginxHome` should show the certificates correctly symlinked to the **full pathname** of the downloaded certificates
-`ls -la $nginxHome/sites-enabled` should show `identity-admin.conf`  correctly symlinked to the **full pathname** of `identity-admin/nginx/identity-admin.conf`
+    - `ls -la $nginxHome` should show the certificates correctly symlinked to the **full pathname** of the downloaded certificates
+    - `ls -la $nginxHome/sites-enabled` should show `identity-admin.conf`  correctly symlinked to the **full pathname** of `identity-admin/nginx/identity-admin.conf`
 
 You should now be able to start the application (`sbt run`), go to [https://idadmin.thegulocal.com/management/healthcheck](https://idadmin.thegulocal.com/management/healthcheck) and see a green padlock for your local SSL certificate as well as a 200 response.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,52 @@
-# identity-admin
+# Identity-admin
+
+# Setting up Identity Admin locally
+
+## Hosts
+
+Ensure you have the correct [identity-admin hosts](https://github.com/guardian/identity-admin/blob/master/nginx/hosts) included in the /etc/hosts file on your machine
+
+## SSL Certificates & nginx setup
+
+We have valid SSL certificates for thegulocal.com and the subdomains we use for local development.
+
+The certificates for the local subdomain idadmin.thegulocal.com are stored in the AWS S3 Identity bucket and are set up as part of the identity-admin.conf for nginx.
+
+Follow these installation steps to correctly setup nginx and valid SSL certificates locally:
+
+* Make sure you are in the base identity-admin directory
+
+* Make sure you have access to the S3 bucket identity-local-ssl and download them using the [AWS CLI utility](https://aws.amazon.com/cli/) (the following command will download them in your current directory using your Identity profile on AWS):
+
+```bash
+aws --profile identity s3 cp s3://identity-local-ssl/idadmin-thegulocal-com-exp2018-09-16-bundle.crt . 1>/dev/null
+aws --profile identity s3 cp s3://identity-local-ssl/idadmin-thegulocal-com-exp2018-09-16.key . 1>/dev/null
+```
+
+* Find the configuration folder of nginx on your machine:
+
+```bash
+nginxHome=`nginx -V 2>&1 | grep "configure arguments:" | sed 's/[^*]*conf-path=\([^ ]*\)\/nginx\.conf.*/\1/g'`
+```
+
+* Create symbolic links for the certificates and identity-admin configuration file for nginx (note: this might require `sudo`)
+
+```bash
+sudo ln -fs `pwd`/idadmin-thegulocal-com-exp2018-09-16-bundle.crt $nginxHome/idadmin-thegulocal-com-exp2018-09-16-bundle.crt
+sudo ln -fs `pwd`/idadmin-thegulocal-com-exp2018-09-16.key $nginxHome/idadmin-thegulocal-com-exp2018-09-16.key
+sudo ln -fs `pwd`/nginx/identity-admin.conf $nginxHome/sites-enabled/identity-admin.conf
+```
+
+* Restart nginx:
+
+```bash
+sudo nginx -s stop
+sudo nginx
+```
+
+* Optional - verify that your configuration is set up as expected
+
+`ls -la $nginxHome` should show the certificates correctly symlinked to the **full pathname** of the downloaded certificates
+`ls -la $nginxHome/sites-enabled` should show `identity-admin.conf`  correctly symlinked to the **full pathname** of `identity-admin/nginx/identity-admin.conf`
+
+You should now be able to start the application (`sbt run`), go to [https://idadmin.thegulocal.com/management/healthcheck](https://idadmin.thegulocal.com/management/healthcheck) and see a green padlock for your local SSL certificate as well as a 200 response.

--- a/build.sbt
+++ b/build.sbt
@@ -11,3 +11,5 @@ riffRaffPackageType := (packageZipTarball in Universal).value
 riffRaffBuildIdentifier := "DEV"
 riffRaffUploadArtifactBucket := "riffraff-artifact"
 riffRaffUploadManifestBucket := "riffraff-builds"
+
+play.PlayImport.PlayKeys.playDefaultPort := 8852

--- a/nginx/hosts
+++ b/nginx/hosts
@@ -1,0 +1,1 @@
+127.0.0.1   idadmin.thegulocal.com                # Identity Admin

--- a/nginx/identity-admin.conf
+++ b/nginx/identity-admin.conf
@@ -1,0 +1,18 @@
+server {
+    listen 443;
+    server_name idadmin.thegulocal.com;
+
+    ssl on;
+    ssl_certificate idadmin-thegulocal-com-exp2018-09-16-bundle.crt;
+    ssl_certificate_key idadmin-thegulocal-com-exp2018-09-16.key;
+
+    ssl_session_timeout 5m;
+
+    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+    ssl_ciphers HIGH:!aNULL:!MD5;
+    ssl_prefer_server_ciphers on;
+
+    location / {
+        proxy_pass http://localhost:8852/;
+    }
+}


### PR DESCRIPTION
- Instead of using the conventional `setup.sh` script for nginx, specifies manual instructions. Reasoning:
  - every user installing should be aware of how the nginx setup works, especially since some operations require `sudo`
  - the script is hard to debug when it fails and can leave the machine in an unexpected state
  - the number of steps to perform is relatively small

- Uses port 8852 instead of default 9000 (risk of conflicts with other applications)



