### PR TITLE
Add Play security filter for default security headers

### DIFF
--- a/app/filters/Filters.scala
+++ b/app/filters/Filters.scala
@@ -1,0 +1,10 @@
+package filters
+
+import javax.inject.Inject
+
+import play.api.http.HttpFilters
+import play.filters.headers.SecurityHeadersFilter
+
+class Filters @Inject() (securityHeadersFilter: SecurityHeadersFilter) extends HttpFilters {
+  def filters = Seq(securityHeadersFilter)
+}

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,8 @@ libraryDependencies ++= Seq(
   "com.gu" %% "play-googleauth" % "0.3.0",
   "org.scalatestplus" %% "play" % "1.4.0-M3",
   "org.webjars" % "bootstrap" % "3.3.5",
-  ws
+  ws,
+  filters
 )
 
 riffRaffPackageType := (packageZipTarball in Universal).value

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -1,5 +1,6 @@
 include file("/etc/gu/identity-admin.conf")
 
 play.http.session.secure=true
+play.http.filters = "filters.Filters"
 
 play.i18n.langs = ["en"]


### PR DESCRIPTION
This PR adds Play's default security headers to all requests.  Including:

sets X-Frame-Options, “DENY” by default.
sets X-XSS-Protection, “1; mode=block” by default.
sets X-Content-Type-Options, “nosniff” by default.
sets X-Permitted-Cross-Domain-Policies, “master-only” by default.
sets Content-Security-Policy, “default-src ‘self’” by default.

For more information see:

https://www.owasp.org/index.php/List_of_useful_HTTP_headers
https://www.playframework.com/documentation/2.4.x/SecurityHeaders
