### PR TITLE
Use scalatest 2.2.5

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,6 +8,7 @@ lazy val root = (project in file(".")).enablePlugins(PlayScala, SbtNativePackage
 
 libraryDependencies ++= Seq(
   "org.scalatestplus" %% "play" % "1.4.0-M3" % "test",
+  "org.scalatest" %% "scalatest" % "2.2.5" % "test",
   "org.mockito" % "mockito-core" % "1.9.5" % "test",
   "com.gu" %% "play-googleauth" % "0.3.2",
   "org.webjars" % "bootstrap" % "3.3.5",


### PR DESCRIPTION
In order to prevent this error: https://github.com/scalatest/scalatest/issues/248 happening when running tests locally on some of our machines