### PR TITLE
Fix search errors

### DIFF
--- a/app/services/RequestSigner.scala
+++ b/app/services/RequestSigner.scala
@@ -36,7 +36,7 @@ trait RequestSigner extends Logging {
   private[services] def getPath(request: WSRequest): String = {
     val uri = request.uri
     val queryString = uri.getQuery
-    if(queryString == null || queryString.isEmpty) uri.getPath else s"${uri.getPath}?${queryString.replace("+","%20")}"
+    if(queryString == null || queryString.isEmpty) uri.getPath else s"${uri.getPath}?${queryString.replace("+","%20").replace("@","%40")}"
   }
 
   private[services] def getDateHeaderValue: String = {

--- a/app/services/RequestSigner.scala
+++ b/app/services/RequestSigner.scala
@@ -35,8 +35,9 @@ trait RequestSigner extends Logging {
 
   private[services] def getPath(request: WSRequest): String = {
     val uri = request.uri
-    val queryString = uri.getQuery
-    if(queryString == null || queryString.isEmpty) uri.getPath else s"${uri.getPath}?${queryString.replace("+","%20").replace("@","%40")}"
+    val queryString = uri.getRawQuery
+    val formattedQueryString = queryString.replace("+", "%20")
+    if(queryString == null || queryString.isEmpty) uri.getPath else s"${uri.getPath}?" + formattedQueryString
   }
 
   private[services] def getDateHeaderValue: String = {

--- a/app/services/RequestSigner.scala
+++ b/app/services/RequestSigner.scala
@@ -36,8 +36,7 @@ trait RequestSigner extends Logging {
   private[services] def getPath(request: WSRequest): String = {
     val uri = request.uri
     val queryString = uri.getRawQuery
-    val formattedQueryString = queryString.replace("+", "%20")
-    if(queryString == null || queryString.isEmpty) uri.getPath else s"${uri.getPath}?" + formattedQueryString
+    if(queryString == null || queryString.isEmpty) uri.getPath else s"${uri.getPath}?" + queryString.replace("+", "%20")
   }
 
   private[services] def getDateHeaderValue: String = {


### PR DESCRIPTION
The play framework encodes spaces in a search query as + 
In order to interact with the api spaces should be encoded as %20
This pr fixes this so that other encoding of special characters such as @ is kept but the + encoding is overwritten