### PR TITLE
Allow inbound traffic from Platforms Teamcity

### DIFF
--- a/cloudformation/identity-admin.json
+++ b/cloudformation/identity-admin.json
@@ -335,6 +335,16 @@
       }
     },
 
+    "PlatformsTeamCityIngress": {
+      "Type": "AWS::EC2::SecurityGroupIngress",
+      "Properties": {
+        "IpProtocol": "tcp",
+        "FromPort": "443",
+        "ToPort": "443",
+        "CidrIp": "52.31.42.37/32"
+      }
+    },
+
     "LoadBalancerSecurityGroup": {
       "Type": "AWS::EC2::SecurityGroup",
       "Properties": {
@@ -346,7 +356,8 @@
             "FromPort": "443",
             "ToPort": "443",
             "CidrIp": { "Ref": "InternalCidrIp" }
-          }
+          },
+          { "Ref": "PlatformsTeamCityIngress" }
         ],
         "SecurityGroupEgress": [
           {

--- a/cloudformation/identity-admin.json
+++ b/cloudformation/identity-admin.json
@@ -339,16 +339,6 @@
       }
     },
 
-    "PlatformsTeamCityIngress": {
-      "Type": "AWS::EC2::SecurityGroupIngress",
-      "Properties": {
-        "IpProtocol": "tcp",
-        "FromPort": "443",
-        "ToPort": "443",
-        "CidrIp": { "Ref": "PlatformsTeamcityCidrIp" }
-      }
-    },
-
     "LoadBalancerSecurityGroup": {
       "Type": "AWS::EC2::SecurityGroup",
       "Properties": {
@@ -359,9 +349,14 @@
             "IpProtocol": "tcp",
             "FromPort": "443",
             "ToPort": "443",
-            "CidrIp": { "Ref": "InternalCidrIp" }
+            "CidrIp": { "Ref": "PlatformsTeamcityCidrIp" }
           },
-          { "Ref": "PlatformsTeamCityIngress" }
+          {
+            "IpProtocol": "tcp",
+            "FromPort": "443",
+            "ToPort": "443",
+            "CidrIp": { "Ref": "InternalCidrIp" }
+          }
         ],
         "SecurityGroupEgress": [
           {

--- a/cloudformation/identity-admin.json
+++ b/cloudformation/identity-admin.json
@@ -81,6 +81,10 @@
       "Description": "Internal network CIDR IP",
       "Type": "String"
     },
+    "PlatformsTeamcityCidrIp": {
+      "Description": "https://github.com/guardian/platforms-teamcity",
+      "Type": "String"
+    },
     "AlarmEmailAddress": {
       "Description": "Contact email for alarms",
       "Type": "String"
@@ -341,7 +345,7 @@
         "IpProtocol": "tcp",
         "FromPort": "443",
         "ToPort": "443",
-        "CidrIp": "52.31.42.37/32"
+        "CidrIp": { "Ref": "PlatformsTeamcityCidrIp" }
       }
     },
 

--- a/cloudformation/identity-admin.json
+++ b/cloudformation/identity-admin.json
@@ -82,7 +82,7 @@
       "Type": "String"
     },
     "PlatformsTeamcityCidrIp": {
-      "Description": "https://github.com/guardian/platforms-teamcity",
+      "Description": "Platforms TeamCity CIDR IP",
       "Type": "String"
     },
     "AlarmEmailAddress": {


### PR DESCRIPTION
@danmassie 

Needed to enable functional tests to run against ID Admin instances.

https://github.com/guardian/platforms-teamcity